### PR TITLE
feat: Add HTTPS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ For example, you've proxy pool `(proxies.txt)` as:
 <table>
 	<td>
 		<pre>http://127.0.0.1:8080
+https://127.0.0.1:443
 socks4://127.0.0.1:4145
 socks5://127.0.0.1:2121
 ...

--- a/pkg/mubeng/transport.go
+++ b/pkg/mubeng/transport.go
@@ -22,7 +22,7 @@ func Transport(p string) (tr *http.Transport, err error) {
 		tr = &http.Transport{
 			Dial: socks.Dial(p),
 		}
-	case "http":
+	case "http", "https":
 		tr = &http.Transport{
 			Proxy: http.ProxyURL(proxyURL),
 		}

--- a/pkg/mubeng/transport_test.go
+++ b/pkg/mubeng/transport_test.go
@@ -17,10 +17,16 @@ func TestTransport(t *testing.T) {
 
 	failProxy := "gopher://localhost:70"
 	httpProxy := "http://localhost:80"
+	httpsProxy := "https://localhost:443"
 	socks4Proxy := "socks4://localhost:5678"
 	socks5Proxy := "socks5://localhost:3128"
 
 	httpURL, err := url.Parse(httpProxy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	httpsURL, err := url.Parse(httpsProxy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,6 +49,18 @@ func TestTransport(t *testing.T) {
 			},
 			wantTr: &http.Transport{
 				Proxy:             http.ProxyURL(httpURL),
+				DisableKeepAlives: true,
+				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Switch-transport to HTTPS",
+			args: args{
+				p: httpProxy,
+			},
+			wantTr: &http.Transport{
+				Proxy:             http.ProxyURL(httpsURL),
 				DisableKeepAlives: true,
 				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 			},


### PR DESCRIPTION
### Summary

_Replacing #126 _

`mubeng` does not support HTTPS proxy as source - an error message `[FTL] Error! no proxy file provided.` pops up when trying to provide proxies starting with `https`.

This PR shall add this feature.


### Proposed of changes

This PR fixes/implements the following **feature**:

- Support `https://` proxy as source.

### How has this been tested?

Proof:

```
➜  mubeng git:(master) ✗ mubeng -f proxy.txt -c -v

           _   v0.9.3-12-ga71acde
 _____ _ _| |_ ___ ___ ___
|     | | | . | -_|   | . |
|_|_|_|___|___|___|_|_|_  |
                      |___|
 infosec@kitabisa.com

[LIVE] [DE] https://aaa:bbb@uk-020.whiskergalaxy.com:443
```

```
➜  mubeng git:(add-https-proxy-2) ✗ go test ./...
?   	ktbs.dev/mubeng/cmd/mubeng	[no test files]
?   	ktbs.dev/mubeng/common	[no test files]
?   	ktbs.dev/mubeng/internal/checker	[no test files]
?   	ktbs.dev/mubeng/internal/daemon	[no test files]
?   	ktbs.dev/mubeng/internal/proxymanager	[no test files]
?   	ktbs.dev/mubeng/internal/runner	[no test files]
?   	ktbs.dev/mubeng/internal/server	[no test files]
?   	ktbs.dev/mubeng/internal/updater	[no test files]
ok  	ktbs.dev/mubeng/pkg/mubeng	0.306s
```

### Closing issues

Fixes #125

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
  - [ x ] I have updated the documentation accordingly.
- [ x ] I have followed the guidelines in our [CONTRIBUTING.md](https://github.com/kitabisa/mubeng/blob/master/.github/CONTRIBUTING.md) document.
- [ x ] I have written new tests for my changes.
- [ x ] My changes successfully ran and pass tests locally.