### PR TITLE
feat: add `--max-redirects` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Here are all the options it supports.
 | -t, --timeout                   | Max. time allowed for proxy server/check (default: 30s).      |
 | -r, --rotate `<AFTER>`          | Rotate proxy IP for every `AFTER` request (default: 1).       |
 |     --max-retries `<N>`         | Max. retries for failed HTTP requests (default: 0).           |
+|     --max-redirects `<N>`       | Max. redirects for HTTP requests (default: 10).               |
 | -m, --method `<METHOD>`         | Rotation method (sequent/random) (default: sequent).          |
 | -s, --sync                      | Sync will wait for the previous request to complete.          |
 | -v, --verbose                   | Dump HTTP request/responses or show died proxy on check.      |

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Here are all the options it supports.
 | -t, --timeout                   | Max. time allowed for proxy server/check (default: 30s).      |
 | -r, --rotate `<AFTER>`          | Rotate proxy IP for every `AFTER` request (default: 1).       |
 |     --max-retries `<N>`         | Max. retries for failed HTTP requests (default: 0).           |
-|     --max-redirects `<N>`       | Max. redirects for HTTP requests (default: 10).               |
+|     --max-redirs `<N>`          | Max. redirects allowed (default: 10).                         |
 | -m, --method `<METHOD>`         | Rotation method (sequent/random) (default: sequent).          |
 | -s, --sync                      | Sync will wait for the previous request to complete.          |
 | -v, --verbose                   | Dump HTTP request/responses or show died proxy on check.      |

--- a/common/options.go
+++ b/common/options.go
@@ -28,4 +28,5 @@ type Options struct {
 	Verbose    bool
 	Watch      bool
 	MaxRetries int
+	MaxRedirects int
 }

--- a/common/options.go
+++ b/common/options.go
@@ -13,20 +13,20 @@ type Options struct {
 	Result       *os.File
 	Timeout      time.Duration
 
-	Address    string
-	Auth       string
-	CC         string
-	Check      bool
-	Countries  []string
-	Daemon     bool
-	File       string
-	Goroutine  int
-	Method     string
-	Output     string
-	Rotate     int
-	Sync       bool
-	Verbose    bool
-	Watch      bool
-	MaxRetries int
+	Address      string
+	Auth         string
+	CC           string
+	Check        bool
+	Countries    []string
+	Daemon       bool
+	File         string
+	Goroutine    int
+	Method       string
+	Output       string
+	Rotate       int
+	Sync         bool
+	Verbose      bool
+	Watch        bool
+	MaxRetries   int
 	MaxRedirects int
 }

--- a/common/vars.go
+++ b/common/vars.go
@@ -1,22 +1,22 @@
 package common
 
 var (
-  // App name
-  App = "mubeng"
-  // Version of mubeng itself
-  Version = ""
-  // Email handles of developer
-  Email = "infosec@kitabisa.com"
-  // Banner of mubeng
-  Banner = `
+	// App name
+	App = "mubeng"
+	// Version of mubeng itself
+	Version = ""
+	// Email handles of developer
+	Email = "infosec@kitabisa.com"
+	// Banner of mubeng
+	Banner = `
            _   ` + Version + `
- _____ _ _| |_ ___ ___ ___ 
+ _____ _ _| |_ ___ ___ ___
 |     | | | . | -_|   | . |
 |_|_|_|___|___|___|_|_|_  |
                       |___|
  ` + Email
-  // Usage of mubeng
-  Usage = `
+	// Usage of mubeng
+	Usage = `
   mubeng [-c|-a :8080] -f file.txt [options...]
 
 Options:
@@ -27,12 +27,12 @@ Options:
     -u, --update                     Update mubeng to the latest stable version
     -v, --verbose                    Verbose mode
     -V, --version                    Show current mubeng version
-  
+
   PROXY CHECKER
     -c, --check                      Perform proxy check
     -g, --goroutine <N>              Max. goroutine to use (default: 50)
         --only-cc <AA>,<BB>          Only for specific country code (comma separated)
-  
+
   IP ROTATOR
     -a, --address <ADDR>:<PORT>      Run proxy server
     -A, --auth <USER>:<PASS>         Set authorization for proxy server
@@ -40,7 +40,7 @@ Options:
     -m, --method <METHOD>            Rotation method (sequent/random) (default: sequent)
     -r, --rotate <N>                 Rotate proxy IP after N request (default: 1)
         --max-retries <N>            Max. retries for failed HTTP requests (default: 0)
-        --max-redirects <N>          Max. redirects for HTTP requests (default: 10)
+        --max-redirs <N>             Max. redirects allowed (default: 10)
     -s, --sync                       Syncrounus mode
     -w, --watch                      Watch proxy file, live-reload from changes
 

--- a/common/vars.go
+++ b/common/vars.go
@@ -40,6 +40,7 @@ Options:
     -m, --method <METHOD>            Rotation method (sequent/random) (default: sequent)
     -r, --rotate <N>                 Rotate proxy IP after N request (default: 1)
         --max-retries <N>            Max. retries for failed HTTP requests (default: 0)
+        --max-redirects <N>          Max. redirects for HTTP requests (default: 10)
     -s, --sync                       Syncrounus mode
     -w, --watch                      Watch proxy file, live-reload from changes
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -61,6 +61,7 @@ func Options() *common.Options {
 	flag.IntVar(&opt.Goroutine, "goroutine", 50, "")
 
 	flag.IntVar(&opt.MaxRetries, "max-retries", 0, "")
+	flag.IntVar(&opt.MaxRedirects, "max-redirects", 10, "")
 
 	flag.Usage = func() {
 		showBanner()

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -61,7 +61,7 @@ func Options() *common.Options {
 	flag.IntVar(&opt.Goroutine, "goroutine", 50, "")
 
 	flag.IntVar(&opt.MaxRetries, "max-retries", 0, "")
-	flag.IntVar(&opt.MaxRedirects, "max-redirects", 10, "")
+	flag.IntVar(&opt.MaxRedirects, "max-redirs", 10, "")
 
 	flag.Usage = func() {
 		showBanner()

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -48,8 +48,9 @@ func (p *Proxy) onRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Reque
 		}
 
 		proxy := &mubeng.Proxy{
-			Address:   rotate,
-			Transport: tr,
+			Address:      rotate,
+			Transport:    tr,
+			MaxRedirects: p.Options.MaxRedirects,
 		}
 
 		client, err := proxy.New(r)
@@ -62,7 +63,6 @@ func (p *Proxy) onRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Reque
 		if p.Options.Verbose {
 			client.Transport = dump.RoundTripper(tr)
 		}
-		client = mubeng.SetMaxRedirects(client, p.Options.MaxRedirects)
 
 		retryablehttpClient := mubeng.ToRetryableHTTPClient(client)
 		retryablehttpClient.RetryMax = p.Options.MaxRetries

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -62,6 +62,7 @@ func (p *Proxy) onRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Reque
 		if p.Options.Verbose {
 			client.Transport = dump.RoundTripper(tr)
 		}
+		client = mubeng.SetMaxRedirects(client, p.Options.MaxRedirects)
 
 		retryablehttpClient := mubeng.ToRetryableHTTPClient(client)
 		retryablehttpClient.RetryMax = p.Options.MaxRetries

--- a/pkg/mubeng/mubeng.go
+++ b/pkg/mubeng/mubeng.go
@@ -48,3 +48,16 @@ func ToRetryableHTTPClient(client *http.Client) *retryablehttp.Client {
 
 	return retryablehttpClient
 }
+
+// SetMaxRedirects sets the maximum number of redirects that the client will follow.
+// If the client follows the maximum number of redirects, it returns the last response it receives.
+func SetMaxRedirects(client *http.Client, maxRedirects int) *http.Client {
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= maxRedirects {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	}
+
+	return client
+}

--- a/pkg/mubeng/mubeng.go
+++ b/pkg/mubeng/mubeng.go
@@ -38,6 +38,13 @@ func (proxy *Proxy) New(req *http.Request) (*http.Client, error) {
 
 	req.Header.Set("X-Forwarded-Proto", req.URL.Scheme)
 
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= proxy.MaxRedirects {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	}
+
 	return client, nil
 }
 
@@ -47,17 +54,4 @@ func ToRetryableHTTPClient(client *http.Client) *retryablehttp.Client {
 	retryablehttpClient.HTTPClient = client
 
 	return retryablehttpClient
-}
-
-// SetMaxRedirects sets the maximum number of redirects that the client will follow.
-// If the client follows the maximum number of redirects, it returns the last response it receives.
-func SetMaxRedirects(client *http.Client, maxRedirects int) *http.Client {
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if len(via) >= maxRedirects {
-			return http.ErrUseLastResponse
-		}
-		return nil
-	}
-
-	return client
 }

--- a/pkg/mubeng/proxy.go
+++ b/pkg/mubeng/proxy.go
@@ -4,6 +4,7 @@ import "net/http"
 
 // Proxy define the IP address value, http.Transport and other additional options.
 type Proxy struct {
-	Address   string
-	Transport *http.Transport
+	Address      string
+	Transport    *http.Transport
+	MaxRedirects int
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first!**

_(Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request)._
### Summary
I've run into a few issues with redirects (#247, #230) that were caused by the fact that the HTTP library in go silently follows 10 redirects and fails without returning the last call.
Clients using the proxy would fail without any insight and without receiving a proper failure code. Moreover, in some use cases, the 3xx code and destination is a result by itself.

### Proposed of changes
This PR adds a --max-retries option that defaults to the standard 10 redirects the HTTP library follows.
In addition to that, the last result is returned in a case of 3xx redirect.

### How has this been tested?

Proof:
```

dyudelevich@MadMacs mubeng % make test
Testing mubeng package v0.15.3-8-g46197be
ok  	github.com/kitabisa/mubeng/pkg/mubeng	0.011s
ok  	github.com/kitabisa/mubeng/pkg/helper	0.008s
```
```
dyudelevich@MadMacs mubeng % make test-extra 
Run GolangCI-Lint
INFO golangci-lint has version 1.60.3 built with go1.23.0 from c2e095c on 2024-08-22T21:45:24Z 
INFO [config_reader] Config search paths: [./ /Users/dyudelevich/dev/mubeng /Users/dyudelevich/dev /Users/dyudelevich /Users /] 
INFO [lintersdb] Active 6 linters: [errcheck gosimple govet ineffassign staticcheck unused] 
INFO [loader] Go packages loading at mode 575 (name|deps|files|imports|types_sizes|compiled_files|exports_file) took 255.663947ms 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 1.423605ms 
INFO [linters_context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 12, after processing: 2 
INFO [runner] Processors filtering stat (in/out): diff: 2/2, max_from_linter: 2/2, path_prettifier: 12/12, skip_files: 12/12, identifier_marker: 12/12, exclude: 12/12, nolint: 2/2, uniq_by_line: 2/2, path_shortener: 2/2, path_prefixer: 2/2, max_same_issues: 2/2, severity-rules: 2/2, fixer: 2/2, cgo: 12/12, filename_unadjuster: 12/12, autogenerated_exclude: 12/12, exclude-rules: 12/2, max_per_file_from_linter: 2/2, source_code: 2/2, invalid_issue: 12/12, skip_dirs: 12/12, sort_results: 2/2 
INFO [runner] processing took 1.172241ms with stages: exclude-rules: 271.921µs, identifier_marker: 211.399µs, autogenerated_exclude: 201.764µs, path_prettifier: 176.97µs, nolint: 167.24µs, source_code: 71.223µs, skip_dirs: 54.732µs, filename_unadjuster: 4.353µs, cgo: 3.798µs, uniq_by_line: 1.896µs, invalid_issue: 1.773µs, max_same_issues: 1.322µs, max_from_linter: 1.012µs, path_shortener: 919ns, fixer: 475ns, max_per_file_from_linter: 403ns, skip_files: 277ns, exclude: 210ns, sort_results: 200ns, diff: 142ns, path_prefixer: 108ns, severity-rules: 104ns 
INFO [runner] linters took 74.893599ms with stages: goanalysis_metalinter: 73.567471ms 
internal/server/init.go:9:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator. (staticcheck)
	rand.Seed(time.Now().UnixNano())
	^
internal/proxymanager/proxymanager.go:23:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator. (staticcheck)
	rand.Seed(time.Now().UnixNano())
	^
INFO File cache stats: 2 entries of total size 1.3KiB 
INFO Memory: 5 samples, avg is 34.4MB, max is 47.3MB 
INFO Execution took 348.222792ms                  
make: *** [golangci-lint] Error 1
``` 
fixing error above will break compatibility with <1.20

Testing below for 301 and following redirects via curl with -L flag:
 `curl -k -v -L -x "http://127.0.0.1:9000" https://httpbin.org/status/301` and `curl -k -v -x "http://127.0.0.1:9000" https://httpbin.org/status/301`
```dyudelevich@MadMacs mubeng % ./bin/mubeng --max-redirects 0 -f proxy -a 127.0.0.1:9000

           _   
 _____ _ _| |_ ___ ___ ___
|     | | | . | -_|   | . |
|_|_|_|___|___|___|_|_|_  |
                      |___|
 infosec@kitabisa.com

2024/09/03 12:41:20 [INFO] ▶ [PID: 76761] Starting proxy server on 127.0.0.1:9000
2024/09/03 12:41:24 [DEBU] ▶ 127.0.0.1:50789 GET https://httpbin.org:443/status/301
2024/09/03 12:41:26 [DEBU] ▶ 127.0.0.1:50789 301 MOVED PERMANENTLY
2024/09/03 12:41:45 [DEBU] ▶ 127.0.0.1:50792 GET https://httpbin.org:443/status/301
2024/09/03 12:41:47 [DEBU] ▶ 127.0.0.1:50792 301 MOVED PERMANENTLY
2024/09/03 12:41:47 [DEBU] ▶ 127.0.0.1:50794 GET https://httpbin.org:443/redirect/1
2024/09/03 12:41:47 [DEBU] ▶ 127.0.0.1:50794 302 FOUND
2024/09/03 12:41:47 [DEBU] ▶ 127.0.0.1:50796 GET https://httpbin.org:443/get
2024/09/03 12:41:48 [DEBU] ▶ 127.0.0.1:50796 200 OK
^C2024/09/03 12:41:51 [WARN] ▶ Interuppted. Exiting...
```

### Closing issues

Fixes #247 , #230 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [X] I have updated the documentation accordingly.
- [X] I have followed the guidelines in our [CONTRIBUTING.md](https://github.com/kitabisa/mubeng/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have written new tests for my changes.
- [X] My changes successfully ran and pass tests locally.