### PR TITLE
runner: reject checker concurrency below one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project should be documented in this file.
 
+### Unreleased
+
+- Patch
+  - Reject proxy checks configured with fewer than one goroutine
+
 ### v0.11.0
 
 - Minor

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Here are all the options it supports.
 | -A, --auth `<USER>:<PASS>`      | Set authorization for proxy server.                           |
 | -d, --daemon                    | Daemonize proxy server.                                       |
 | -c, --check                     | To perform proxy live check.                                  |
-| -g, --goroutine `<N>`           | Max. goroutine to use (default: 50).                          |
+| -g, --goroutine `<N>`           | Max. concurrent goroutines (min: 1; 1 runs checks serially; default: 50). |
 |     --only-cc `<AA>,<BB>`       | Only show specific country code (comma separated).            |
 | -t, --timeout                   | Max. time allowed for proxy server/check (default: 30s).      |
 | -r, --rotate `<AFTER>`          | Rotate proxy IP for every `AFTER` request (default: 1).       |

--- a/common/vars.go
+++ b/common/vars.go
@@ -31,7 +31,7 @@ Options:
 
   PROXY CHECKER
     -c, --check                      Perform proxy check
-    -g, --goroutine <N>              Max. goroutine to use (default: 50)
+    -g, --goroutine <N>              Max. concurrent goroutines (min: 1; 1 runs checks serially; default: 50)
         --only-cc <AA>,<BB>          Only for specific country code (comma separated)
         --output-format <FORMAT>     Custom output format using fasttemplate syntax
                                      Available variables: {{proxy}}, {{protocol}},

--- a/internal/runner/validator.go
+++ b/internal/runner/validator.go
@@ -14,6 +14,10 @@ import (
 
 // validate user-supplied option values before Runner.
 func validate(opt *common.Options) error {
+	if opt.Address == "" && opt.Check && opt.Goroutine < 1 {
+		return errors.New("goroutine must be at least 1 when using --check")
+	}
+
 	var err error
 
 	if hasStdin() {


### PR DESCRIPTION
### Summary

Checker mode currently passes `--goroutine` values below one to `sourcegraph/conc`, which panics before Mubeng can return a CLI error.
This change validates the effective checker path before input/output side effects and documents one as serial execution.

### Proposed of changes

This PR fixes the following bug:

- Reject checker concurrency below one with an actionable runner validation error.
- Keep address/server mode unchanged when the checker-only flag is unused.
- Document the minimum, serial value, and default in existing CLI help and README text.
- Add the required changelog entry.

### Evidence

- Issue #313 contains the current-master reproduction and prior-art review.
- [`conc v0.3.0`](https://github.com/sourcegraph/conc/blob/v0.3.0/pool/pool.go#L87-L95) panics when the configured maximum is below one.

### Risks and boundaries

- No upper cap is introduced.
- Valid checker values remain unchanged.
- Checker transport/result concurrency and server-mode validation remain outside this fix.

### How has this been tested?

Proof:

- `make build` — passed.
- `make test` — passed for the repository's configured package scope.
- `./bin/mubeng -f FILE -c -g=-1` and `-g 0` — returned the validation error without a panic.
- The same command with `-g 1` and `-g 50` — completed normally.
- `./bin/mubeng -h` — rendered the new minimum and serial-mode text.
- Go formatting and LSP diagnostics — passed.

### Closing issues

Fixes #313

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I have followed the guidelines in `CONTRIBUTING.md`.
- [ ] I have written new tests for my changes.
- [x] My changes successfully ran and pass tests locally.

### Disclosure

Investigated thoroughly with GPT-5.6 (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.