### PR TITLE
server: route SIGTERM through graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project should be documented in this file.
 
+### Unreleased
+
+- Patch
+  - Handle SIGTERM gracefully when running the proxy server
+
 ### v0.11.0
 
 - Minor

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/elazarl/goproxy"
 	"github.com/henvic/httpretty"
@@ -65,7 +66,7 @@ func Run(opt *common.Options) {
 	}
 
 	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, os.Interrupt)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 	go interrupt(stop)
 
 	log.Infof("%d proxies loaded", opt.ProxyManager.Count())


### PR DESCRIPTION
### Summary

The server registers `os.Interrupt` but not `SIGTERM`, so normal service and container termination can bypass Mubeng's existing shutdown path.
This change registers `SIGTERM` on the same channel without changing `Stop` behavior.

### Proposed of changes

This PR fixes the following bug:

- Register `syscall.SIGTERM` beside `os.Interrupt` in `server.Run`.
- Preserve the existing interrupt goroutine, shutdown order, timeout, and SIGINT behavior.
- Add the required changelog entry.

### Evidence

- Issue #314 contains the current-master SIGTERM/SIGINT reproduction and lifecycle analysis.
- PR #227 is related shutdown history but does not handle `SIGTERM`.

### Risks and boundaries

- Signals received before registration retain the operating system's default behavior.
- Existing gateway locking, remote-close, ignored-error, watcher, and service-callback behavior remains unchanged.
- The installed-service path is source-proven; this verification exercised the direct server process.

### How has this been tested?

Proof:

- `make build` — passed.
- `make test` — passed for the repository's configured package scope.
- Start server, send `SIGTERM` — logged `Interrupted. Exiting...` and exited zero.
- Start the same server, send `SIGINT` — logged the same message and exited zero.
- Go formatting and LSP diagnostics — passed.

### Closing issues

Fixes #314

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I have followed the guidelines in `CONTRIBUTING.md`.
- [ ] I have written new tests for my changes.
- [x] My changes successfully ran and pass tests locally.

### Disclosure

Investigated thoroughly with GPT-5.6 (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.