### PR TITLE
build: include every package in the short test target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project should be documented in this file.
 
+### Unreleased
+
+- Patch
+  - Test every module package in the short test target
+
 ### v0.11.0
 
 - Minor

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,31 @@ APP_NAME = mubeng
 VERSION  = $(shell git describe --always --tags)
 LINT_CMD = "golangci-lint run ./... -v --timeout 5m"
 LINT_BIN = "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh"
+TEST_CMD = go test -short ./...
 
 mubeng: test build
 
 test:
-	@echo "Testing ${APP_NAME} package ${VERSION}"
-	@go test -short github.com/mubeng/mubeng/pkg/mubeng
-	@go test -short github.com/mubeng/mubeng/pkg/helper
+	@if [ "$(VERBOSE)" = "1" ]; then \
+		$(TEST_CMD); \
+	else \
+		output_file=$$(mktemp "$${TMPDIR:-/tmp}/mubeng-test.XXXXXX" 2>&1); \
+		status=$$?; \
+		if [ "$$status" -ne 0 ]; then \
+			printf 'test: failed (exit %s)\n' "$$status"; \
+			printf '%s\n' "$$output_file"; \
+			exit "$$status"; \
+		fi; \
+		trap 'rm -f "$$output_file"' 0; \
+		if $(TEST_CMD) >"$$output_file" 2>&1; then \
+			printf '%s\n' 'test: ok'; \
+		else \
+			status=$$?; \
+			printf 'test: failed (exit %s)\n' "$$status"; \
+			cat "$$output_file"; \
+			exit "$$status"; \
+		fi; \
+	fi
 
 test-extra: golangci-lint test
 


### PR DESCRIPTION
### Summary

The repository test target explicitly names two packages and skips the maintained `pkg/helper/awsurl` tests.
This change makes one module-scoped command own the package scope and keeps default success output compact.

### Proposed of changes

This PR fixes the following build/test gap:

- Run `go test -short ./...` as the single test-scope command.
- Print only `test: ok` on default success.
- Preserve actionable raw output and the underlying command status on failure.
- Stream normal Go output when `VERBOSE=1` is selected.
- Keep `test-extra` and the linter target otherwise unchanged.
- Add the required changelog entry.

### Evidence

- Issue #315 contains the current-master reproduction and package inventory.
- PR #261 added `pkg/helper/awsurl` after the explicit test target was created.

### Risks and boundaries

- `./...` also compiles module packages without tests and retains Go's default vet behavior.
- Quiet mode uses `mktemp` and removes its output file through a shell trap.
- GNU Make returns its normal nonzero recipe status while the output reports the underlying test exit code.
- Linter installation and fallback behavior remain outside this change.

### How has this been tested?

Proof:

- `make test` — printed only `test: ok` and passed all three maintained test packages.
- `make test VERBOSE=1` — streamed the full module package scope, including `pkg/helper/awsurl`.
- An injected test command exiting 7 — printed `test: failed (exit 7)` plus raw sentinel output and returned nonzero.
- Temp-file inspection after success and failure — no task-created files remained.

### Closing issues

Fixes #315

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I have followed the guidelines in `CONTRIBUTING.md`.
- [ ] I have written new tests for my changes.
- [x] My changes successfully ran and pass tests locally.

### Disclosure

Investigated thoroughly with GPT-5.6 (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.