### PR TITLE
daemon: preserve server retry options in service arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project should be documented in this file.
 
+### Unreleased
+
+- Patch
+  - Forward retry and error-handling options to daemon services
+
 ### v0.11.0
 
 - Minor

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/kardianos/service"
-	"github.com/projectdiscovery/gologger"
 	"github.com/mubeng/mubeng/common"
+	"github.com/projectdiscovery/gologger"
 )
 
 // New to initialize mubeng in daemon
@@ -20,6 +20,9 @@ func New(opt *common.Options) error {
 		"-r", strconv.Itoa(opt.Rotate),
 		"-m", opt.Method,
 		"-o", opt.Output,
+		"--max-errors", strconv.Itoa(opt.MaxErrors),
+		"--max-redirs", strconv.Itoa(opt.MaxRedirects),
+		"--max-retries", strconv.Itoa(opt.MaxRetries),
 	}
 
 	if opt.Sync {
@@ -32,6 +35,14 @@ func New(opt *common.Options) error {
 
 	if opt.Watch {
 		args = append(args, "-w")
+	}
+
+	if opt.RotateOnErr {
+		args = append(args, "--rotate-on-error")
+	}
+
+	if opt.RemoveOnErr {
+		args = append(args, "--remove-on-error")
 	}
 
 	o := make(service.KeyValue)


### PR DESCRIPTION
### Summary

Daemon installation manually copies only part of the parsed server configuration into `service.Config.Arguments`.
This change preserves the five omitted retry and error-handling values when the service child reparses its arguments.

### Proposed of changes

This PR fixes the following mapping gap:

- Forward enabled `--rotate-on-error` and `--remove-on-error` flags.
- Always forward `--max-errors`, `--max-redirs`, and `--max-retries`, including zero and negative values.
- Preserve existing server arguments and exclude checker/control options.
- Add the required changelog entry.

### Evidence

- Issue #316 contains the current-master mapping analysis, debugger evidence, and prior-art review.
- Commit `3c343f7` previously fixed the same manually maintained mapping for older daemon options.

### Risks and boundaries

- Service quoting, stdin lifetime, SIGTERM handling, Windows issue #220, and service lifecycle remain unchanged.
- No generic options serializer is introduced.
- Verification observed the final argument slice before `service.New`; it did not install or start a service.

### How has this been tested?

Proof:

- `make build` — passed.
- `make test` — passed for the repository's configured package scope.
- Delve breakpoint before `service.New` — observed all five selected values in the final 22-element argument slice:

```text
--max-errors -1 --max-redirs 0 --max-retries 2 --rotate-on-error --remove-on-error
```

- Go formatting and LSP diagnostics — passed.

### Closing issues

Fixes #316

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I have followed the guidelines in `CONTRIBUTING.md`.
- [ ] I have written new tests for my changes.
- [x] My changes successfully ran and pass tests locally.

### Disclosure

Investigated thoroughly with GPT-5.6 (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.